### PR TITLE
Update the gnosis safe api url.

### DIFF
--- a/packages/core/src/helpers/gnosisSafeUtils.ts
+++ b/packages/core/src/helpers/gnosisSafeUtils.ts
@@ -88,9 +88,9 @@ export const calculateSafeTransactionHash = (
 export const getLatestNonce = async (chainId: number, safeAddress: string): Promise<number | null | undefined> => {
   try {
     const response = await fetch(
-      `https://safe-transaction.${
+      `https://safe-transaction-${
         getChainById(chainId)?.chainName
-      }.gnosis.io/api/v1/safes/${safeAddress}/all-transactions?limit=1&executed=false&queued=true`
+      }.safe.global/api/v1/safes/${safeAddress}/all-transactions?limit=1&executed=false&queued=true`
     )
     if (!response.ok) return null
     const allTransactions = await response.json()


### PR DESCRIPTION
The address used to access the gnosis safe API changed in 2023: https://forum.safe.global/t/announcement-to-all-builders-using-safe-services/3225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the URL in the safe transaction fetching process to ensure accurate and reliable data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->